### PR TITLE
added fix for holiday scenario

### DIFF
--- a/pde_poc.Tests/Engine/MV/ExecutorIntegrationTests.cs
+++ b/pde_poc.Tests/Engine/MV/ExecutorIntegrationTests.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+
+using Xunit;
+
+using pde_poc_sim.Engine;
+using pde_poc_sim.Engine.Lib;
+
+using pde_poc_sim.OpenFisca;
+
+using RestSharp;
+
+namespace pde_poc.Tests
+{
+    public class ExecutorIntegrationTests
+    {
+        
+        [Fact(Skip="Integration test")]
+        public void ShouldSucceedInAllScenarios()
+        {
+            var sut = GetSystem();
+
+            var simulationCase = GetBaseCase();
+
+            var testCases = GetSchedules();
+
+            foreach (var testCase in testCases) {
+                var person = new MotorVehiclePerson() {
+                    WeeklySchedule = testCase.Item1
+                };
+                var result = sut.Execute(simulationCase, person);
+                Assert.Equal(testCase.Item2, result);
+            }
+        }
+
+        private MotorVehicleRuleExecutor GetSystem() {
+            var restClient = new RestClient();
+            var openFiscaOptions = new OpenFiscaOptions() {
+                Url = "https://openfiscacanada-dts-csps-main.dev.dts-stn.com"
+            };
+            var options = Options.Create(openFiscaOptions);
+
+            var openFiscaLib = new OpenFiscaLib(restClient, options);
+
+            var dailyRequestBuilder = new DailyRequestBuilder();
+            var dailyResultExtractor = new DailyResultExtractor();
+            var aggregateRequestBuilder = new AggregateRequestBuilder();
+            var aggregateResultExtractor = new AggregateResultExtractor();
+            var executor = new MotorVehicleRuleExecutor(openFiscaLib, dailyRequestBuilder, aggregateRequestBuilder, dailyResultExtractor, aggregateResultExtractor);
+
+            return executor;
+        }
+
+        private MotorVehicleSimulationCase GetBaseCase() {
+            return new MotorVehicleSimulationCase() {
+                StandardCmvoDaily = 9,
+                StandardCmvoWeekly = 45,
+                StandardOtherDaily = 8,
+                StandardOtherWeekly = 40,
+                StandardHighwayWeekly = 60,
+                StandardHighwayReduction = 10
+            };
+        }
+
+        private List<Tuple<MvoSchedule,decimal>> GetSchedules() {
+            var result = new List<Tuple<MvoSchedule, decimal>>();
+
+            var scenario1 = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(0,8,4,false),
+                    new HourSet(0,4,8,false),
+                    new HourSet(0,10,0,false),
+                    new HourSet(0,0,10,false),
+                    new HourSet(0,6,6,false),
+                    new HourSet(0,0,8,false),
+                    new HourSet(0,0,0,false),
+                }
+            };
+            result.Add(new Tuple<MvoSchedule, decimal>(scenario1, 4m));
+
+            var scenario2 = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(8,0,4,false),
+                    new HourSet(4,0,8,false),
+                    new HourSet(10,0,0,false),
+                    new HourSet(0,0,10,false),
+                    new HourSet(6,0,6,false),
+                    new HourSet(0,5,0,false),
+                    new HourSet(0,0,0,false),
+                }
+            };
+            result.Add(new Tuple<MvoSchedule, decimal>(scenario2, 16m));
+
+            var scenario3 = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(6,0,6,false),
+                    new HourSet(6,0,6,false),
+                    new HourSet(10,0,0,false),
+                    new HourSet(8,2,0,false),
+                    new HourSet(6,0,6,false),
+                    new HourSet(0,5,0,false),
+                    new HourSet(0,0,0,false),
+                }
+            };
+            result.Add(new Tuple<MvoSchedule, decimal>(scenario3, 13m));
+
+            var scenario4 = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(9,0,0,false),
+                    new HourSet(9,0,0,false),
+                    new HourSet(9,0,0,false),
+                    new HourSet(9,0,0,false),
+                    new HourSet(9,0,0,false),
+                    new HourSet(0,0,4,false),
+                    new HourSet(0,0,0,false),
+                }
+            };
+            result.Add(new Tuple<MvoSchedule, decimal>(scenario4, 4m));
+
+            var scenario6 = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(4,4,5,false),
+                    new HourSet(4,5,4,false),
+                    new HourSet(5,4,4,false),
+                    new HourSet(4,4,5,false),
+                    new HourSet(4,5,4,false),
+                    new HourSet(0,0,0,false),
+                    new HourSet(0,0,0,false),
+                }
+            };
+            result.Add(new Tuple<MvoSchedule, decimal>(scenario6, 5m));
+
+            var scenario7 = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(4,4,6,false),
+                    new HourSet(4,6,4,false),
+                    new HourSet(6,4,4,false),
+                    new HourSet(5,5,5,false),
+                    new HourSet(0,0,0,false),
+                    new HourSet(0,4,0,false),
+                    new HourSet(0,0,0,false),
+                }
+            };
+            result.Add(new Tuple<MvoSchedule, decimal>(scenario7, 5m));
+
+            var scenario8 = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(8,4,0,false),
+                    new HourSet(8,0,4,false),
+                    new HourSet(0,2,8,false),
+                    new HourSet(0,0,0,true),
+                    new HourSet(8,4,0,false),
+                    new HourSet(0,6,4,false),
+                    new HourSet(0,0,0,false),
+                }
+            };
+            result.Add(new Tuple<MvoSchedule, decimal>(scenario8, 6m));
+
+            var scenario9 = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(8,4,0,false),
+                    new HourSet(8,0,4,false),
+                    new HourSet(0,2,8,false),
+                    new HourSet(6,5,1,true),
+                    new HourSet(8,4,0,false),
+                    new HourSet(0,6,4,false),
+                    new HourSet(0,0,0,false),
+                }
+            };
+            result.Add(new Tuple<MvoSchedule, decimal>(scenario9, 6m));
+
+            var scenario10 = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(0,4,10,false),
+                    new HourSet(0,12,6,false),
+                    new HourSet(13,0,1,false),
+                    new HourSet(0,14,0,false),
+                    new HourSet(4,0,9,false),
+                    new HourSet(0,0,0,false),
+                    new HourSet(0,0,0,false),
+                }
+            };
+            result.Add(new Tuple<MvoSchedule, decimal>(scenario10, 13m));
+
+            var scenario11 = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(0,12,0,false),
+                    new HourSet(0,12,0,false),
+                    new HourSet(0,12,0,false),
+                    new HourSet(0,12,0,false),
+                    new HourSet(10,0,2,false),
+                    new HourSet(0,0,0,false),
+                    new HourSet(0,0,0,false),
+                }
+            };
+            result.Add(new Tuple<MvoSchedule, decimal>(scenario11, 3m));
+
+            var scenario12 = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(0,0,12,false),
+                    new HourSet(0,14,0,false),
+                    new HourSet(10,0,0,false),
+                    new HourSet(0,6,10,false),
+                    new HourSet(0,12,0,false),
+                    new HourSet(0,0,6,false),
+                    new HourSet(0,0,0,false),
+                }
+            };
+            result.Add(new Tuple<MvoSchedule, decimal>(scenario12, 10m));
+
+            var scenario13 = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(8,0,0,false),
+                    new HourSet(8,0,0,false),
+                    new HourSet(8,0,0,false),
+                    new HourSet(0,0,10,false),
+                    new HourSet(0,0,0,false),
+                    new HourSet(0,10,0,false),
+                    new HourSet(0,0,0,false),
+                }
+            };
+            result.Add(new Tuple<MvoSchedule, decimal>(scenario13, 2m));
+
+            return result;
+        }
+    }
+
+
+}

--- a/pde_poc.Tests/Engine/MV/MotorVehiclePersonTests.cs
+++ b/pde_poc.Tests/Engine/MV/MotorVehiclePersonTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+using pde_poc_sim.Engine;
+
+namespace pde_poc.Tests
+{
+    public class MotorVehiclePersonTests
+    {
+        
+        [Fact]
+        public void ShouldCalculateWeeklyWithoutHoliday()
+        {
+            // Arrange
+            var schedule = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(1, 2, 3, false),
+                    new HourSet(4, 5, 6, false),
+                }
+            };
+
+            // Act
+            var person = new MotorVehiclePerson() {
+                WeeklySchedule = schedule
+            };
+
+            
+            // Assert
+            Assert.Equal(5, person. WeeklyCmvoHours);
+            Assert.Equal(7, person. WeeklyHmvoHours);
+            Assert.Equal(9, person. WeeklyOtherHours);
+            Assert.Equal(0, person.NumHolidays);
+        }
+
+        [Fact]
+        public void ShouldCalculateWeeklyWithHoliday()
+        {
+            // Arrange
+            var schedule = new MvoSchedule() {
+                Hours = new List<HourSet>() {
+                    new HourSet(1, 2, 3, false),
+                    new HourSet(1, 2, 3, true),
+                    new HourSet(4, 5, 6, false),
+                }
+            };
+
+            // Act
+            var person = new MotorVehiclePerson() {
+                WeeklySchedule = schedule
+            };
+
+            
+            // Assert
+            Assert.Equal(5, person. WeeklyCmvoHours);
+            Assert.Equal(7, person. WeeklyHmvoHours);
+            Assert.Equal(9, person. WeeklyOtherHours);
+            Assert.Equal(1, person.NumHolidays);
+        }
+    }
+}

--- a/pde_poc.Tests/OpenFisca/AggregateRequestBuilderTests.cs
+++ b/pde_poc.Tests/OpenFisca/AggregateRequestBuilderTests.cs
@@ -31,15 +31,14 @@ namespace pde_poc.Tests
             Assert.Null(result.GetProp(personName, OF.TotalOTHours));
             Assert.Equal(1, result.GetProp(personName, OF.NumHolidaysInPeriod));
             Assert.Equal(0, result.GetProp(personName, OF.WeeklyBusHours));
-            Assert.Equal(8d, result.GetProp(personName, OF.WeeklyCmvoHours));
-            Assert.Equal(14d, result.GetProp(personName, OF.WeeklyHmvoHours));
-            Assert.Equal(17d, result.GetProp(personName, OF.WeeklyOtherHours));
+            Assert.Equal(7d, result.GetProp(personName, OF.WeeklyCmvoHours));
+            Assert.Equal(13d, result.GetProp(personName, OF.WeeklyHmvoHours));
+            Assert.Equal(16d, result.GetProp(personName, OF.WeeklyOtherHours));
 
             Assert.Equal(8d, result.GetProp(personName, OF.StandardClcDailyHours));
             Assert.Equal(40d, result.GetProp(personName, OF.StandardClcWeeklyHours));
             Assert.Equal(9d, result.GetProp(personName, OF.StandardCmvoDailyHours));
             Assert.Equal(45d, result.GetProp(personName, OF.StandardCmvoWeeklyHours));
-            //Assert.Equal(9d, result.GetProp(personName, OF.StandardCmvoHolidayReduction));
             Assert.Equal(10d, result.GetProp(personName, OF.StandardHmvoHolidayReduction));
             Assert.Equal(60d, result.GetProp(personName, OF.StandardHmvoWeeklyHours));
 

--- a/pde_poc_sim/Engine/Classes/MV/MotorVehiclePerson.cs
+++ b/pde_poc_sim/Engine/Classes/MV/MotorVehiclePerson.cs
@@ -20,19 +20,25 @@ namespace pde_poc_sim.Engine
 
         public double WeeklyHmvoHours {
             get {
-                return WeeklySchedule.Hours.Sum(x => x.HoursHmvo);
+                return WeeklySchedule.Hours
+                    .Where(x => !x.IsHoliday)
+                    .Sum(x => x.HoursHmvo);
             }
         }
 
         public double WeeklyCmvoHours {
             get {
-                return WeeklySchedule.Hours.Sum(x => x.HoursCmvo);
+                return WeeklySchedule.Hours
+                    .Where(x => !x.IsHoliday)
+                    .Sum(x => x.HoursCmvo);
             }
         }
 
         public double WeeklyOtherHours {
             get {
-                return WeeklySchedule.Hours.Sum(x => x.HoursOther);
+                return WeeklySchedule.Hours
+                    .Where(x => !x.IsHoliday)
+                    .Sum(x => x.HoursOther);
             }
         }
 

--- a/pde_poc_sim/OpenFisca/DailyRequest/DailyRequestBuilder.cs
+++ b/pde_poc_sim/OpenFisca/DailyRequest/DailyRequestBuilder.cs
@@ -24,7 +24,7 @@ namespace pde_poc_sim.OpenFisca
                 result.SetProp(personName, OF.StandardClcDailyHours, rule.StandardOtherDaily);
                 result.SetProp(personName, OF.StandardCmvoDailyHours, rule.StandardCmvoDaily);
 
-                // Any need to add holiday hours?
+                result.SetProp(personName, OF.IsHoliday, hourSet.IsHoliday);
             }
             return result;
         }

--- a/pde_poc_sim/OpenFisca/OpenFiscaVariables.cs
+++ b/pde_poc_sim/OpenFisca/OpenFiscaVariables.cs
@@ -10,6 +10,7 @@ namespace pde_poc_sim.OpenFisca
         public const string DailyCmvoHours = "daily_work_schedule__total_hours_city_operator";
         public const string DailyBusHours = "daily_work_schedule__total_hours_bus_operator";
         public const string DailyOtherHours = "daily_work_schedule__total_hours_other";
+        public const string IsHoliday = "daily_work_schedule__is_holiday";
 
 
         // Aggregate

--- a/pde_poc_web/Views/MotorVehicle/Form.cshtml
+++ b/pde_poc_web/Views/MotorVehicle/Form.cshtml
@@ -43,7 +43,7 @@
                                 <span class="text-danger" asp-validation-for="Person.Hours[i].HoursOther"></span>
                             </td>
                             <td class="text-center">
-                                <input type="checkbox" asp-for="Person.Hours[i].IsHoliday"/>
+                                <input class="is-holiday-toggle" data-dayid="@i" type="checkbox" asp-for="Person.Hours[i].IsHoliday"/>
                             </td>
                             <td class="text-center">
                                 <span class="font-weight-bold day-total"></span>

--- a/pde_poc_web/wwwroot/js/site.js
+++ b/pde_poc_web/wwwroot/js/site.js
@@ -1,10 +1,19 @@
 ﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
 // for details on configuring this project to bundle and minify static web assets.
 
-// Write your JavaScript code.
 $(".hour-input").change(updateFormTotals);
 
-$("#table-schedule").ready(updateFormTotals);
+$("#table-schedule").ready(x => {
+    checkHolidayToggles();
+    updateFormTotals();
+});
+
+$(".is-holiday-toggle").change(e => {
+    var checked = $(e.target).prop("checked");
+    var rowData = $(e.target).closest("tr").find("td");
+    toggleHoliday(rowData, checked);
+    updateFormTotals();
+});
 
 function updateFormTotals() {
     var scheduleRows = $("#table-schedule tr");
@@ -35,4 +44,28 @@ function updateFormTotals() {
     $(lastRow).find("td.hmvo-total").text(totalHmvo);
     $(lastRow).find("td.other-total").text(totalOther);
     $(lastRow).find("td.grand-total").text(grandTotal);
+}
+
+function checkHolidayToggles() {
+    var scheduleRows = $("#table-schedule tr");
+
+    for (var i = 1; i < scheduleRows.length - 1; i++) {
+        var rowData = $(scheduleRows[i]).find("td"); 
+        var checked = $(rowData[4]).find("input").prop("checked");
+        if (checked) {
+            toggleHoliday(rowData, true);
+        }
+    }
+}
+
+function toggleHoliday(rowData, toggle) {
+    // Set values to 0
+    $(rowData[1]).find("input").val(0);
+    $(rowData[2]).find("input").val(0);
+    $(rowData[3]).find("input").val(0);
+
+    // Disable/Enable them
+    $(rowData[1]).find("input").prop("disabled", toggle);
+    $(rowData[2]).find("input").prop("disabled", toggle);
+    $(rowData[3]).find("input").prop("disabled", toggle);
 }


### PR DESCRIPTION
Fixes for holidays:
- Added in the holiday parameter on the daily calculation
- Javascript to disable ability to edit hours on day marked as holiday
- weekly hours calculation that gets sent to openfisca will omit any hours that are included on holiday (which is impossible anyways without being hacky, based on the previous point)
- Unit tests around holiday hours
- Added integration tests for all scenarios

![screencapture-localhost-6001-2021-03-25-12_21_52](https://user-images.githubusercontent.com/18725437/112507074-b8b44500-8d64-11eb-8c98-c4065170a6ff.png)
